### PR TITLE
Fix fetch redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-script-polyfills",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Polyfills to give browser and/or node apis in magicscript",
   "module": "src/polyfills.js",
   "dependencies": {},

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -6,6 +6,7 @@ import { decoder, encoder } from './weblit-js/libs/http-codec.js';
 import { readFileStream, writeFileStream, prepareBody, expandBody } from './fs.js';
 import { connect } from './tcp.js';
 import { Headers } from './headers.js';
+import { resolveUrl } from './resolve.js';
 export { Headers };
 
 export let fetch = makeFetch({
@@ -237,7 +238,8 @@ async function httpRequest (req, redirected = 0) {
         if (redirected > 5) {
           throw new Error('Too many redirects');
         }
-        return httpRequest(new Request(res.headers.Location), redirected + 1);
+        let location = resolveUrl(req.url, res.headers.Location);
+        return httpRequest(new Request(location), redirected + 1);
       }
     }
     if (req.redirect === 'error') {

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -1,0 +1,32 @@
+export function resolveUrl (baseUrl, url) {
+  let [, protocol, host, path] = url.match(/^([a-z]+:)?(\/\/[^/]+)?(.*)$/);
+  if (protocol && host) return url;
+  let [, baseProtocol, baseHost, basePath] = baseUrl.match(/^([a-z]+:)?(\/\/[^/]+)?(.*)$/);
+  if (host) {
+    return baseProtocol + host + path;
+  }
+  return baseProtocol + baseHost + resolvePath(basePath, path);
+}
+
+export function resolvePath (basePath, path) {
+  let parts;
+  if (path[0] === '/') {
+    parts = path.split('/');
+  } else {
+    let baseParts = basePath.split('/');
+    baseParts.pop();
+    parts = baseParts.concat(path.split('/'));
+  }
+  let stack = [];
+  for (let part of parts) {
+    if (!part || part === '.') {
+      continue;
+    }
+    if (part === '..') {
+      stack.pop();
+    } else {
+      stack.push(part);
+    }
+  }
+  return '/' + stack.join('/');
+}

--- a/tests/test-fetch-2.js
+++ b/tests/test-fetch-2.js
@@ -1,0 +1,8 @@
+import { fetch } from '../src/fetch.js';
+
+
+async function main() {
+  let response = await fetch("https://loremflickr.com/320/240", {redirect: 'follow'});
+  print(response)
+}
+main()

--- a/tests/test-resolve.js
+++ b/tests/test-resolve.js
@@ -1,0 +1,16 @@
+import { resolveUrl } from '../src/resolve.js';
+
+function check (actual, expected) {
+  print('Expected: ', expected);
+  print('Actual:   ', actual);
+  if (actual !== expected) {
+    throw new Error('Sanity check failed');
+  }
+}
+check(resolveUrl('http://test.com/foo/bar', '/baz'), 'http://test.com/baz');
+check(resolveUrl('http://test.com/foo/bar', 'baz'), 'http://test.com/foo/baz');
+check(resolveUrl('http://test.com/foo/bar', './baz'), 'http://test.com/foo/baz');
+check(resolveUrl('http://test.com/foo/bar', '../baz'), 'http://test.com/baz');
+check(resolveUrl('http://test.com/foo/bar', '//test.org/baz'), 'http://test.org/baz');
+check(resolveUrl('https://test.com/foo/bar', '//test.org/baz'), 'https://test.org/baz');
+print('All tests pass!');

--- a/tests/test-resolve.js
+++ b/tests/test-resolve.js
@@ -8,9 +8,14 @@ function check (actual, expected) {
   }
 }
 check(resolveUrl('http://test.com/foo/bar', '/baz'), 'http://test.com/baz');
+check(resolveUrl('http://test.com/foo/', '/baz'), 'http://test.com/baz');
 check(resolveUrl('http://test.com/foo/bar', 'baz'), 'http://test.com/foo/baz');
+check(resolveUrl('http://test.com/foo/', 'baz'), 'http://test.com/foo/baz');
 check(resolveUrl('http://test.com/foo/bar', './baz'), 'http://test.com/foo/baz');
+check(resolveUrl('http://test.com/foo/', './baz'), 'http://test.com/foo/baz');
 check(resolveUrl('http://test.com/foo/bar', '../baz'), 'http://test.com/baz');
+check(resolveUrl('http://test.com/foo/', '../baz'), 'http://test.com/baz');
 check(resolveUrl('http://test.com/foo/bar', '//test.org/baz'), 'http://test.org/baz');
 check(resolveUrl('https://test.com/foo/bar', '//test.org/baz'), 'https://test.org/baz');
+check(resolveUrl('http://test.com/foo/bar', 'https://test.com/foo/bar'), 'https://test.com/foo/bar');
 print('All tests pass!');


### PR DESCRIPTION
There was a bug in weblit's parser for chunked encoding, fixed upstream and updated submodule.
Also I had forgot that redirects can be relative urls and needs to be resolved.

Added regression test for fetch and unit test for new resolve code.