### PR TITLE
Fix small bugs in timers and websocket polyfills

### DIFF
--- a/src/timers.js
+++ b/src/timers.js
@@ -22,7 +22,9 @@ export function setTimeout (fn, delay = 0, ...args) {
  * @param {Timer} timer - The identifier of the timeout you want to cancel.
  */
 export function clearTimeout (timer) {
-  timer.close();
+  if (timer) {
+    timer.close();
+  }
 }
 
 /**
@@ -48,7 +50,9 @@ export function setInterval (fn, delay, ...args) {
  * @param {Timer} timer - The identifier of the interval you want to cancel.
  */
 export function clearInterval (timer) {
-  timer.close();
+  if (timer) {
+    timer.close();
+  }
 }
 
 let check;

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -104,16 +104,27 @@ export class WebSocket extends Evented {
     Object.defineProperty(this, writeKey, { value: write });
     this.readyState = WebSocket.OPEN;
     this.emit('open');
+
+    function makeMessageEvent(data) {
+      return {
+        data,
+        origin: '',
+        lastEventId: '',
+        source: null,
+        ports: []
+      }
+    }
+
     let frame;
     while ((frame = await read())) {
       // print('FRAME IN', JSON.stringify(frame, null, 2));
       switch (frame.opcode) {
         case 1: // text
-          this.emit('message', frame.payload);
+          this.emit('message', makeMessageEvent(frame.payload));
           break;
         case 2: // binary
           if (this.binaryType === 'arraybuffer') {
-            this.emit('message', frame.payload);
+            this.emit('message', makeMessageEvent(frame.payload));
             break;
           }
           throw new Error('Unsupported binaryType: ' + this.binaryType);


### PR DESCRIPTION
- clearTimeout and clearInterval gracefully handle null param
- WebSocket onmessage callback delivers payload inside 'data' key