### PR TITLE
Add cache to fetch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /latest.zip
 /test.txt
 /wscat
+/fetchcache/

--- a/src-ts/writable-path.ts
+++ b/src-ts/writable-path.ts
@@ -1,0 +1,19 @@
+let path: string | undefined;
+type Listener = (newPath: string | undefined) => void
+const listeners: Listener[] = [];
+
+
+export function on(fn: Listener) {
+    listeners.push(fn);
+}
+
+export function getPath(): string | undefined {
+    return path;
+}
+
+export function setPath(newPath: string | undefined) {
+    path = newPath;
+    for (const listener of listeners) {
+        listener(newPath);
+    }
+}

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -12,3 +12,4 @@
 /Storage.*
 /fs-sync.*
 /size.*
+/writable-path.*

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -2,6 +2,7 @@
 
 import "./console.js";
 import process from "./node/process.js";
+import { pathJoin } from "./utils2.js";
 
 import {
   clearImmediate,
@@ -20,6 +21,7 @@ import {
   WebSocket,
   XMLHttpRequest,
 } from './index.js';
+import { on as onWritablePath } from "./writable-path.js";
 
 // Browser globals
 globalThis.clearImmediate = clearImmediate;
@@ -43,3 +45,7 @@ globalThis.XMLHttpRequest = XMLHttpRequest;
 globalThis.global = globalThis;
 globalThis.process = process;
 
+onWritablePath((newPath) => {
+  globalThis.localStorage.updateBase(pathJoin(newPath, 'localstorage'));
+  fetch.setCacheFolder(pathJoin(newPath, 'fetchcache'));
+})

--- a/tests/fetch-cache.js
+++ b/tests/fetch-cache.js
@@ -19,15 +19,8 @@ async function main(name) {
     await fetch('https://creationix.com/content/images/2016/11/IMG_20161115_073457.jpg').then(logRes);
 
     const res = await fetch('https://lit.luvit.io/').then(logRes);
-    // console.log(i, res);
-    // return res.cachePath;
-    // console.log(name, { arrayBuffer: await res.arrayBuffer() });
-    // console.log(name, { text: await res.text() });
-    // console.log(name, { json: await res.json() });
     const data = await res.json();
     const authors = await fetch(data.authors).then(logRes).then(res => res.json());
-    return authors;
-    // console.log(authors);
     return Promise.all(
         Object.keys(authors).map(async (name) => [
             name,

--- a/tests/fetch-cache.js
+++ b/tests/fetch-cache.js
@@ -1,0 +1,55 @@
+import '../src/polyfills.js';
+import { setPath } from '../src/writable-path.js';
+import { fetch } from '../src/fetch.js';
+
+// Enable filesystem persistence.
+setPath('.');
+
+
+async function main(name) {
+
+    async function logRes(res) {
+        console.log(name, res.status, res.url, { Via: res.headers.get('Via') }, await res.cacheFile, ' ');
+        return res;
+    }
+
+    await fetch('https://creationix.github.io/minecss').then(logRes);
+    await fetch('http://luvit.io/logo-white.svg').then(logRes);
+    await fetch('https://creationix.com/content/images/2016/11/Logo_V2.png').then(logRes);
+    await fetch('https://creationix.com/content/images/2016/11/IMG_20161115_073457.jpg').then(logRes);
+
+    const res = await fetch('https://lit.luvit.io/').then(logRes);
+    // console.log(i, res);
+    // return res.cachePath;
+    // console.log(name, { arrayBuffer: await res.arrayBuffer() });
+    // console.log(name, { text: await res.text() });
+    // console.log(name, { json: await res.json() });
+    const data = await res.json();
+    const authors = await fetch(data.authors).then(logRes).then(res => res.json());
+    return authors;
+    // console.log(authors);
+    return Promise.all(
+        Object.keys(authors).map(async (name) => [
+            name,
+            await fetch(authors[name]).then(res => res.json())
+        ])
+    );
+}
+
+let count = 0;
+const timer = setInterval(() => {
+    if (count++ >= 10) return clearInterval(timer);
+
+    for (let i = 0; i++ < 2; i) {
+        let name = `${count}.${i}`;
+        const start = Date.now();
+        console.log("Starting", name);
+        main(name)
+            .then(data =>
+                console.log('Finished', name, Date.now() - start, typeof data))
+            .catch(err => {
+                i = count = Infinity;
+                print(err.stack);
+            })
+    }
+}, 500);


### PR DESCRIPTION
## Shared Writable path module

- Added `writable-path` module so we have a single place to configure the writable path.
  - Now used by localStorage and fetch cache.

## Implement start to fetch cache

- Added all fetch cache policies:
```js
const cacheConfig = {
  'default': { useCache: true, conditionalRequest: true, updateCache: true },
  'no-store': {},
  'reload': { updateCache: true },
  'no-cache': { conditionalRequest: true, updateCache: true },
  'force-cache': { useCache: true, allowStale: true, updateCache: true },
  'only-if-cached': { useCache: true, allowStale: true, skipNet: true },
};
```
- Fetch defaults to `default` policy if writable path has been configured and `no-store` otherwise.
- Concurrent GET requests for the same resource are now combined and share the same request/response.
  - Note that iterating on `res.body` directly may cause problems, but using the `res.json()` `res.text()`, `res.arrayBuffer()` methods are safe.
- Check for local file cache if policy has `useCache`
  - Assume cache is stale unless `allowStale` is true.  We can optimize this more in the future.
- Perform conditional requests on stale cache if `conditionalRequest` policy flag set.
- Use cached response if not stale or server responds with 304.
- Return 504 (per spec) if no cache and `skipNet` is set.
- Store successful 200 responses to file cache if `updateCache` policy flag is set

## Expose cached file path

- Added a non-standard `res.cacheFile` which is a `Promise<string>` if caching is turned on. Example usage:
```js
async function downloadToDisk() {
    const res = await fetch("https://some.domain/path/to/image.png");
    const filePath = await res.cacheFile;
    // filePath is now a path to the downloaded file in the cache.
}
```

## Bug fixes

- BUG: Fixed fetch response to use correct status code reasons messages instead of always "OK"
- BUG: Path normalization was eating trailing slashes in urls causing sometimes recursive redirects.
- BUG: Fix early error reporting if a non-reusable stream (such as TCP or file) is reused.
- BUG: Give proper responses for file requests, especially give a 404 if the file isn't found.
- BUG: Include missing url in file responses.