### PR TITLE
Add helper function to decode image dimensions using JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-script-polyfills",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Polyfills to give browser and/or node apis in magicscript",
   "module": "src/polyfills.js",
   "dependencies": {},

--- a/src-ts/size.ts
+++ b/src-ts/size.ts
@@ -1,0 +1,46 @@
+
+export function getSize(data: Uint8Array) {
+    // tslint:disable: no-bitwise
+    if (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47 && data[4] === 0x0d && data[5] === 0x0a && data[6] === 0x1a && data[7] === 0x0a) {
+        // PNG header found!
+        return {
+            type: 'png',
+            width: data[16] << 24 | data[17] << 16 | data[18] << 8 | data[19],
+            height: data[20] << 24 | data[21] << 16 | data[22] << 8 | data[23],
+            depth: data[24],
+        };
+    }
+    if (data[0] === 0xff && data[1] === 0xd8) {
+        // JPEG found maybe
+        let offset = 2;
+        while (offset < data.length) {
+            if (data[offset++] !== 0xff) break; // It wasn't a jpeg after all.
+            const marker = data[offset++];
+            if (marker === 0xc0 || marker === 0xc2) {
+                // SOF marker found
+                return {
+                    type: 'jpeg',
+                    width: data[offset + 5] << 8 | data[offset + 6],
+                    height: data[offset + 3] << 8 | data[offset + 4],
+                    depth: data[offset + 2],
+                };
+            } else {
+                // Skip the marker by reading the length.
+                offset += data[offset] << 8 | data[offset + 1];
+            }
+        }
+    }
+    if (data[0] === 0x38 && data[1] === 0x42 && data[2] === 0x50 && data[3] === 0x53) {
+        // Photoshop image found!
+        return {
+            type: 'psd',
+            width: data[14] << 24 | data[15] << 16 | data[16] << 8 | data[17],
+            height: data[18] << 24 | data[19] << 16 | data[20] << 8 | data[21],
+            depth: data[22] << 8 | data[23],
+        };
+    }
+    return {
+        type: "unknown"
+    };
+}
+

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -11,3 +11,4 @@
 /crypto.*
 /Storage.*
 /fs-sync.*
+/size.*

--- a/tests/test-size.js
+++ b/tests/test-size.js
@@ -1,0 +1,17 @@
+// Create list with `find ~/Downloads/ -type f \( -iname \*.jpg -o -iname \*.png \) > images.txt`
+
+import { readfileSync } from '../src/fs-sync.js';
+import '../src/polyfills.js';
+import { getSize } from '../src/size.js';
+import { utf8Decode } from "../src/utils2.js";
+
+for (const file of utf8Decode(readfileSync('images-master.txt', 'r', 0o644)).split('\n').filter(Boolean)) {
+    const data = readfileSync(file, 'r', 0o644);
+    const meta = getSize(data);
+    meta.name = file.split('/').pop();
+    console.log(meta);
+    if (typeof meta.width !== 'number' || typeof meta.height !== 'number') {
+        console.log(file, data);
+        throw new Error("Failed to get metadata");
+    }
+}


### PR DESCRIPTION
Fixes #25 

I tested this using 3226 different images found in my `~/Downloads` and `~/Pictures` folders and it was able to get the correct dimensions out of them all.